### PR TITLE
Added schema version

### DIFF
--- a/function-descriptor/examples/firewall-vnfd.yml
+++ b/function-descriptor/examples/firewall-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "vnfd-schema-01"
+descriptor_version: "1.0"
 
 vendor: "eu.sonata-nfv"
 name: "firewall-vnf"

--- a/function-descriptor/examples/iperf-vnfd.yml
+++ b/function-descriptor/examples/iperf-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "vnfd-schema-01"
+descriptor_version: "1.0"
 
 vendor: "eu.sonata-nfv"
 name: "iperf-vnf"

--- a/function-descriptor/examples/tcpdump-vnfd.yml
+++ b/function-descriptor/examples/tcpdump-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "vnfd-schema-01"
+descriptor_version: "1.0"
 
 vendor: "eu.sonata-nfv"
 name: "tcpdump-vnf"

--- a/function-descriptor/examples/vtc-vnfd.yml
+++ b/function-descriptor/examples/vtc-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "vnfd-schema-01"
+descriptor_version: "1.0"
 
 vendor: "eu.sonata-nfv"
 name: "vtc-vnf"

--- a/function-descriptor/vnfd-metadata-schema.yml
+++ b/function-descriptor/vnfd-metadata-schema.yml
@@ -1,6 +1,7 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/vnfd-metadata-schema-01"
+version: 0.9
 description: >
   The schema for SONATA network function descriptor metatada.
   The metadata is stored inside the SONATA service platform

--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -1,6 +1,8 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/vnfd-schema-02"
+title: "Virtual Network Function Descriptor Schema"
+version: 1.0
 description: "The core schema for SONATA network function descriptors."
 
 ##

--- a/function-record/vnfr-schema.yml
+++ b/function-record/vnfr-schema.yml
@@ -1,6 +1,7 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/vnfr-schema-01"
+version: 0.9
 description: "The core schema for SONATA network function records."
 
 ##

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -1,7 +1,8 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
-#id: "http://www.sonata-nfv.eu/schema/nsd-schema-02-recursive"
-description: "The core scheme for RECUSRIVE service descriptors (many details left out)"
+title: "Network Service Descriptor Schema"
+version: 1.0
+description: "The core schema for network service descriptors (supports recursive network services)"
 
 ##
 ## Some definitions used later on.

--- a/service-record/nsr-schema.yml
+++ b/service-record/nsr-schema.yml
@@ -1,6 +1,7 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/nsd-schema-02-recursive"
+version: 0.9
 description: "The core scheme for RECUSRIVE service record (many details left out)"
 
 ##


### PR DESCRIPTION
In all function and service schemas, I added a `version` field to allow referencing a specific version of a schema inside a descriptor. If the schema changes and the version increments, old descriptors are still valid when checked against the old version of the schema.
Also adjusted the `descriptor_version` fields in the descriptors accordingly.