### PR TITLE
Added logo and version fields to schemas

### DIFF
--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -127,6 +127,10 @@ properties:
   description:
     description: "A longer description of the network function."
     type: "string"
+  logo:
+    description: "Path to VNF logo."
+    type: "string"
+    pattern: "^[A-Za-z0-9\\-_./]+$"
   licenses:
     description: "Information on the license of this VNFD."
     type: "array"

--- a/function-record/vnfr-schema.yml
+++ b/function-record/vnfr-schema.yml
@@ -140,6 +140,10 @@ properties:
     description: "The version of the function record. Can be used to track changes."
     type: "string"
     pattern: "^[0-9]+$"
+  logo:
+    description: "Path to VNF logo."
+    type: "string"
+    pattern: "^[A-Za-z0-9\\-_./]+$"
   status:
     description: "The current status of the VNF"
     enum:

--- a/service-descriptor/examples/recursive-example.yml
+++ b/service-descriptor/examples/recursive-example.yml
@@ -107,3 +107,7 @@ forwarding_graphs:
           - connection_point_ref: "output"
             position: 6
 
+# Testing tags to select appropriate tests in the V&V
+testing_tags:
+  - "latency"
+  - "throughput"

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -412,6 +412,13 @@ properties:
                 type: "string"
       action: 
         type: "string"
+  # tags to select network service for correct tests later (eg, latency tests)
+  testing_tags:
+    type: "array"
+    items:
+      type: "string"
+    uniqueItems: true
+  
 required: 
   - descriptor_version
   - vendor 

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -54,6 +54,10 @@ properties:
   description:
     description: "A longer description of the network service."
     type: "string"
+  logo:
+    description: "Path to service logo."
+    type: "string"
+    pattern: "^[A-Za-z0-9\\-_./]+$"
   licences:
     description: "Information on the licence of this NSD."
     type: "array"

--- a/service-record/nsr-schema.yml
+++ b/service-record/nsr-schema.yml
@@ -71,6 +71,10 @@ properties:
     description: "The version of the service record. Can be used to track changes."
     type: "string"
     pattern: "^[0-9]+$"
+  logo:
+    description: "Path to service logo."
+    type: "string"
+    pattern: "^[A-Za-z0-9\\-_./]+$"
   status:
     description: "The current status of the Service"
     enum:

--- a/slice-descriptor/nst-schema.yml
+++ b/slice-descriptor/nst-schema.yml
@@ -57,6 +57,10 @@ properties:
   description:
     description: "A longer description of the network service."
     type: "string"
+  logo:
+    description: "Path to slice logo."
+    type: "string"
+    pattern: "^[A-Za-z0-9\\-_./]+$"
   licences:
     description: "Information on the licence of this NST."
     type: "array"

--- a/slice-descriptor/nst-schema.yml
+++ b/slice-descriptor/nst-schema.yml
@@ -1,6 +1,8 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/nst-schema"
+title: "Network Slice Template Schema"
+version: 1.0
 description: "The core scheme for network slice template"
 
 ##

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -61,6 +61,10 @@ properties:
   description:
     description: "A longer description of the network service."
     type: "string"
+  logo:
+    description: "Path to slice logo."
+    type: "string"
+    pattern: "^[A-Za-z0-9\\-_./]+$"
   licences:
     description: "Information on the licence of this NST."
     type: "array"

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -1,6 +1,7 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/nst-schema"
+version: 1.0
 description: "The core scheme for network slice template"
 
 ##


### PR DESCRIPTION
Now all schemas (package, service, function, slice) have a version number and an optional logo field.