### PR TITLE
Extended schemas & descriptors

### DIFF
--- a/function-descriptor/README.md
+++ b/function-descriptor/README.md
@@ -14,6 +14,7 @@ Below we discuss the various section of a network function descriptor. The gener
 At the root level, we first have the mandatory fields, that describe and identify the virtual network function in a unique way.
 
 - **descriptor_version** identifies the version of the function descriptor schema that is used to describe the network function.
+- **descriptor_type** identifies the type of descriptor based on the organization (e.g., `eu.5gtango.nsd`)
 - **$schema** (optional) provides a link to the schema that is used to describe the network function and can be used to validate the VNF descriptor file. This is related to the original JSON schema specification.
 
 Moreover, the VNF signature, i.e the *vendor*, the *name*, and the *version*, is of great importance as it identifies the VNF uniquely.

--- a/function-descriptor/examples/firewall-vnfd.yml
+++ b/function-descriptor/examples/firewall-vnfd.yml
@@ -7,6 +7,7 @@
 ## VNF descriptor.
 ##
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.vnfd"
 
 vendor: "eu.sonata-nfv"
 name: "firewall-vnf"

--- a/function-descriptor/examples/firewall-vnfd.yml
+++ b/function-descriptor/examples/firewall-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv"
 name: "firewall-vnf"

--- a/function-descriptor/examples/iperf-vnfd.yml
+++ b/function-descriptor/examples/iperf-vnfd.yml
@@ -7,6 +7,7 @@
 ## VNF descriptor.
 ##
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.vnfd"
 
 vendor: "eu.sonata-nfv"
 name: "iperf-vnf"

--- a/function-descriptor/examples/iperf-vnfd.yml
+++ b/function-descriptor/examples/iperf-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv"
 name: "iperf-vnf"

--- a/function-descriptor/examples/tcpdump-vnfd.yml
+++ b/function-descriptor/examples/tcpdump-vnfd.yml
@@ -7,6 +7,7 @@
 ## VNF descriptor.
 ##
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.vnfd"
 
 vendor: "eu.sonata-nfv"
 name: "tcpdump-vnf"

--- a/function-descriptor/examples/tcpdump-vnfd.yml
+++ b/function-descriptor/examples/tcpdump-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv"
 name: "tcpdump-vnf"

--- a/function-descriptor/examples/vtc-vnfd.yml
+++ b/function-descriptor/examples/vtc-vnfd.yml
@@ -6,7 +6,7 @@
 ## Some general information regarding this
 ## VNF descriptor.
 ##
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv"
 name: "vtc-vnf"

--- a/function-descriptor/examples/vtc-vnfd.yml
+++ b/function-descriptor/examples/vtc-vnfd.yml
@@ -7,6 +7,7 @@
 ## VNF descriptor.
 ##
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.vnfd"
 
 vendor: "eu.sonata-nfv"
 name: "vtc-vnf"

--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -2,7 +2,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/vnfd-schema-02"
 title: "Virtual Network Function Descriptor Schema"
-version: 1.0
+version: 0.9
 description: "The core schema for SONATA network function descriptors."
 
 ##

--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -109,6 +109,9 @@ properties:
     description: "The version of the description definition used to describe the function descriptor."
     type: "string"
     pattern: "^[A-Za-z0-9\\-_.]+$"
+  descriptor_type:
+    description: "The type of descriptor based on the organization, eg, eu.5gtango.nsd for a 5GTANGO NSD."
+    type: "string"
   vendor:
     description: "The vendor id allows to identify a VNF descriptor uniquely across all function descriptor vendors."
     type: "string"
@@ -646,6 +649,7 @@ properties:
         - notification
 required:
   - descriptor_version
+  - descriptor_type
   - vendor 
   - name
   - version

--- a/package-specification/examples/5gtango-ns-package-example/Definitions/mynsd.yaml
+++ b/package-specification/examples/5gtango-ns-package-example/Definitions/mynsd.yaml
@@ -1,5 +1,6 @@
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.nsd"
 
 vendor: "eu.5gtango"
 name: "myns"

--- a/package-specification/examples/5gtango-ns-package-example/Definitions/myvnfd.yaml
+++ b/package-specification/examples/5gtango-ns-package-example/Definitions/myvnfd.yaml
@@ -1,5 +1,6 @@
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.vnfd"
 
 vendor: "eu.5gtango"
 name: "myvnf"

--- a/package-specification/examples/5gtango-ns-package-example/Images/mycloudimage.ref
+++ b/package-specification/examples/5gtango-ns-package-example/Images/mycloudimage.ref
@@ -1,5 +1,7 @@
 ---
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.ref"
+
 name: "mycloudimage"
 vendor: "eu.5gtango"
 version: "16.04"

--- a/package-specification/examples/5gtango-ns-package-example/TOSCA-Metadata/NAPD.yaml
+++ b/package-specification/examples/5gtango-ns-package-example/TOSCA-Metadata/NAPD.yaml
@@ -1,5 +1,6 @@
 ---
 descriptor_version: "0.9"                            # will be 1.0 on first release
+descriptor_type: "eu.5gtango.napd"
 
 vendor: "eu.5gtango"
 name: "ns-package-example"

--- a/package-specification/examples/5gtango-test-package-example/TOSCA-Metadata/NAPD.yaml
+++ b/package-specification/examples/5gtango-test-package-example/TOSCA-Metadata/NAPD.yaml
@@ -1,5 +1,6 @@
 ---
 descriptor_version: "0.9"                            # will be 1.0 on first release
+descriptor_type: "eu.5gtango.napd"
 
 vendor: "eu.5gtango"
 name: "test-package-example"

--- a/package-specification/examples/5gtango-vnf-package-example/Definitions/myvnfd.yaml
+++ b/package-specification/examples/5gtango-vnf-package-example/Definitions/myvnfd.yaml
@@ -1,5 +1,7 @@
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.vnfd"
+
 
 vendor: "eu.5gtango"
 name: "myvnf"

--- a/package-specification/examples/5gtango-vnf-package-example/Images/mycloudimage.ref
+++ b/package-specification/examples/5gtango-vnf-package-example/Images/mycloudimage.ref
@@ -1,5 +1,7 @@
 ---
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.ref"
+
 name: "mycloudimage"
 vendor: "eu.5gtango"
 version: "16.04"

--- a/package-specification/examples/5gtango-vnf-package-example/TOSCA-Metadata/NAPD.yaml
+++ b/package-specification/examples/5gtango-vnf-package-example/TOSCA-Metadata/NAPD.yaml
@@ -1,5 +1,6 @@
 ---
 descriptor_version: "0.9"                            # will be 1.0 on first release
+descriptor_type: "eu.5gtango.napd"
 
 vendor: "eu.5gtango"
 name: "vnf-package-example"

--- a/package-specification/napd-schema.yml
+++ b/package-specification/napd-schema.yml
@@ -6,7 +6,7 @@ version: 0.9
 description: |
   The NFV advanced package descriptor schema specifies
   the structure  of the package descriptor. It makes sure
-  the relevantinformation is provided to parse the package
+  the relevant information is provided to parse the package
   in a meaningful way.
 
 ##
@@ -25,6 +25,9 @@ properties:
     description: "The version of the descriptor schema used."
     type: "string"
     pattern: "^[A-Za-z0-9\\-_.]+$"
+  descriptor_type:
+    description: "The type of descriptor based on the organization, eg, eu.5gtango.nsd for a 5GTANGO NSD."
+    type: "string"
 
   ##
   ## Some general information that describes the package as such.
@@ -109,6 +112,7 @@ properties:
 
 required:
   - "descriptor_version"
+  - "descriptor_type"
   - "vendor"
   - "name"
   - "version"

--- a/package-specification/ref-schema.yml
+++ b/package-specification/ref-schema.yml
@@ -54,6 +54,9 @@ properties:
     description: "The version of the descriptor schema used."
     type: "string"
     pattern: "^[A-Za-z0-9\\-_.]+$"
+  descriptor_type:
+    description: "The type of descriptor based on the organization, eg, eu.5gtango.nsd for a 5GTANGO NSD."
+    type: "string"
   vendor:
     description: "The vendor id will identify the package uniquely across all package."
     type: "string"
@@ -90,6 +93,7 @@ properties:
 
 required:
   - "descriptor_version"
+  - "descriptor_type"
   - "vendor"
   - "name"
   - "version"

--- a/service-descriptor/README.md
+++ b/service-descriptor/README.md
@@ -14,6 +14,7 @@ Below we discuss the various section of a network service descriptor. The genera
 At the root level, we first have the mandatory fields, that describe and identify the virtual network service in a unique way.
 
 - **descriptor_version** identifies the version of the service descriptor schema that is used to describe the network service.
+- **descriptor_type** identifies the type of descriptor based on the organization (e.g., `eu.5gtango.nsd`)
 - **$schema** (optional) provides a link to the schema that is used to describe the network service and can be used to validate the VNF descriptor file. This is related to the original JSON schema specification.
 
 Moreover, the service signature, i.e the *vendor*, the *name*, and the *version*, is of great importance as it identifies the network service uniquely.

--- a/service-descriptor/examples/recursive-example.yml
+++ b/service-descriptor/examples/recursive-example.yml
@@ -5,19 +5,15 @@
 ## @author Stefan Schneider
 ##
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.tango-nfv.service-descriptor"
 name: "recursive-sonata"
 version: "0.1"
 author: "Stefan Schneider, Paderborn University"
-description: >
-  "Example recursive network service reusing the sonata-demo NS and adding a vTC at the beginning."
+description: "Example recursive network service reusing the sonata-demo NS and adding a vTC at the beginning."
 
-##
-## The various network functions this service
-## is composed of.
-##
+# This service uses an extra vTC VNF in addition to the Sonata NS (see below)
 network_functions:
   - vnf_id: "vnf_vtc"
     vnf_vendor: "eu.sonata-nfv"
@@ -111,3 +107,7 @@ forwarding_graphs:
 testing_tags:
   - "latency"
   - "throughput"
+  
+# Soft constraints asking for proximity of the VNF and the reused NS (just as an example)
+soft_constraints:
+  - "proximity:vnf_vtc-ns_sonata"

--- a/service-descriptor/examples/recursive-example.yml
+++ b/service-descriptor/examples/recursive-example.yml
@@ -6,6 +6,7 @@
 ##
 ---
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.nsd"
 
 vendor: "eu.tango-nfv.service-descriptor"
 name: "recursive-sonata"

--- a/service-descriptor/examples/simplest-example.yml
+++ b/service-descriptor/examples/simplest-example.yml
@@ -6,7 +6,7 @@
 ## @author Michael Bredel
 ##
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv.service-descriptor"
 name: "simplest-example"

--- a/service-descriptor/examples/simplest-example.yml
+++ b/service-descriptor/examples/simplest-example.yml
@@ -7,6 +7,7 @@
 ##
 ---
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.nsd"
 
 vendor: "eu.sonata-nfv.service-descriptor"
 name: "simplest-example"

--- a/service-descriptor/examples/sonata-demo-with-ssm.yml
+++ b/service-descriptor/examples/sonata-demo-with-ssm.yml
@@ -7,7 +7,7 @@
 ## @author Manuel Peuster
 ##
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv.service-descriptor"
 name: "sonata-demo"

--- a/service-descriptor/examples/sonata-demo-with-ssm.yml
+++ b/service-descriptor/examples/sonata-demo-with-ssm.yml
@@ -8,6 +8,7 @@
 ##
 ---
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.nsd"
 
 vendor: "eu.sonata-nfv.service-descriptor"
 name: "sonata-demo"

--- a/service-descriptor/examples/sonata-demo.yml
+++ b/service-descriptor/examples/sonata-demo.yml
@@ -7,7 +7,7 @@
 ## @author Michael Bredel
 ##
 ---
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.sonata-nfv.service-descriptor"
 name: "sonata-demo"

--- a/service-descriptor/examples/sonata-demo.yml
+++ b/service-descriptor/examples/sonata-demo.yml
@@ -8,6 +8,7 @@
 ##
 ---
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.nsd"
 
 vendor: "eu.sonata-nfv.service-descriptor"
 name: "sonata-demo"

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -17,7 +17,7 @@ definitions:
       - "ethernet"
       - "ipv4"
       - "ipv6"
-
+  
 
 # actual schema of NSDs
 type: "object"
@@ -26,6 +26,10 @@ properties:
     description: "The version of the description definition used to describe the network descriptor."
     type: "string"
     pattern: "^[A-Za-z0-9\\-_.]+$"
+  descriptor_type:
+    description: "The type of descriptor based on the organization, eg, eu.5gtango.nsd for a 5GTANGO NSD."
+    type: "string"
+    # TODO: restrict to possible types (all permutations of organizations and types)
   vendor:
     description: "The vendor id allows to identify a VNF descriptor uniquely across all function descriptor vendors."
     type: "string"
@@ -426,6 +430,7 @@ properties:
   
 required: 
   - descriptor_version
+  - descriptor_type
   - vendor 
   - name
   - version

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -415,12 +415,12 @@ properties:
     uniqueItems: true
     
   # soft constraints by developer, eg, proximity constraints
-  # TODO: pattern may be restricted to "name:info1-info2-..."?
+  # TODO: more restrictive pattern?
   soft_constraints:
     type: "array"
     items:
       type: "string"
-      pattern: "^[a-z0-9\\-_.]+$"
+      pattern: "[A-Za-z0-9\\-_.:]+"
     uniqueItems: true
   
   

--- a/service-descriptor/nsd-schema.yml
+++ b/service-descriptor/nsd-schema.yml
@@ -1,12 +1,11 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 title: "Network Service Descriptor Schema"
-version: 1.0
+version: 0.9
 description: "The core schema for network service descriptors (supports recursive network services)"
 
-##
-## Some definitions used later on.
-##
+
+# definitions used later
 definitions:
   connection_point_types:
     enum:
@@ -19,18 +18,9 @@ definitions:
       - "ipv4"
       - "ipv6"
 
-##
-## The actual document description.
-##
+
+# actual schema of NSDs
 type: "object"
-# Ensure that the NS includes VNFs or NSs (recursive) or both, ie, a network_functions or network_services section
-# If a network_functions or network_services section is included, it needs to contain 1+ VNF or NS, respectively
-# Is this check wanted? simplest-example.yml doesn't include any VNF or NS...
-# anyOf:
-  # - required:
-    # - network_functions
-  # - required:
-    # - network_services
 properties:
   descriptor_version:
     description: "The version of the description definition used to describe the network descriptor."
@@ -416,12 +406,23 @@ properties:
                 type: "string"
       action: 
         type: "string"
+        
   # tags to select network service for correct tests later (eg, latency tests)
   testing_tags:
     type: "array"
     items:
       type: "string"
     uniqueItems: true
+    
+  # soft constraints by developer, eg, proximity constraints
+  # TODO: pattern may be restricted to "name:info1-info2-..."?
+  soft_constraints:
+    type: "array"
+    items:
+      type: "string"
+      pattern: "^[a-z0-9\\-_.]+$"
+    uniqueItems: true
+  
   
 required: 
   - descriptor_version

--- a/slice-descriptor/examples/slice-template-example.yml
+++ b/slice-descriptor/examples/slice-template-example.yml
@@ -10,6 +10,7 @@ s_nssai:
   sd: 1
       
 descriptor_version: "0.9"
+descriptor_type: "eu.5gtango.nst"
 
 vendor: "eu.5gtango.slice-descriptor"
 name: "slice"

--- a/slice-descriptor/examples/slice-template-example.yml
+++ b/slice-descriptor/examples/slice-template-example.yml
@@ -9,7 +9,7 @@ s_nssai:
   sst: 1 # eMBB
   sd: 1
       
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.5gtango.slice-descriptor"
 name: "slice"

--- a/slice-descriptor/nst-schema.yml
+++ b/slice-descriptor/nst-schema.yml
@@ -41,6 +41,9 @@ properties:
     description: "The version of the description definition used to describe the network descriptor."
     type: "string"
     pattern: "^[A-Za-z0-9\\-_.]+$"
+  descriptor_type:
+    description: "The type of descriptor based on the organization, eg, eu.5gtango.nsd for a 5GTANGO NSD."
+    type: "string"
   vendor:
     description: "The vendor id allows to identify a VNF descriptor uniquely across all function descriptor vendors."
     type: "string"
@@ -180,6 +183,7 @@ properties:
         
 required: 
   - descriptor_version
+  - descriptor_type
   - vendor 
   - name
   - version

--- a/slice-descriptor/nst-schema.yml
+++ b/slice-descriptor/nst-schema.yml
@@ -2,7 +2,7 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/nst-schema"
 title: "Network Slice Template Schema"
-version: 1.0
+version: 0.9
 description: "The core scheme for network slice template"
 
 ##

--- a/slice-record/examples/slice-record-example.yml
+++ b/slice-record/examples/slice-record-example.yml
@@ -11,7 +11,7 @@ s_nssai:
   sst: 1 # eMBB
   sd: 1
       
-descriptor_version: "1.0"
+descriptor_version: "0.9"
 
 vendor: "eu.5gtango.slice-descriptor"
 name: "slice"

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -1,7 +1,7 @@
 ---
 $schema: "http://json-schema.org/draft-04/schema#"
 #id: "http://www.sonata-nfv.eu/schema/nst-schema"
-version: 1.0
+version: 0.9
 description: "The core scheme for network slice template"
 
 ##


### PR DESCRIPTION
* Added soft_constraints to NSDs for policies
* Set schema versions to 0.9 (before our 1st release)
* Added descriptor_type to all schemas and example descriptors. See documentation here: https://github.com/sonata-nfv/tng-schema/wiki/Descriptor-Type