### PR TITLE
minor update of default NSD and VNFD

### DIFF
--- a/function-descriptor/examples/default-vnfd.yml
+++ b/function-descriptor/examples/default-vnfd.yml
@@ -5,10 +5,10 @@
 ---
 descriptor_schema: "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/function-descriptor/vnfd-schema.yml"
 
-vendor: "tango"
+vendor: "eu.5gtango"
 name: "ubuntu-vnf"
 version: "0.9"
-author: "tango"
+author: "eu.5gtango"
 description: "A default ubuntu VNF descriptor"
 
 
@@ -48,7 +48,7 @@ virtual_deployment_units:
         type: "internal"
         
         
-# vnf connection points to the outside world
+# VNF connection points to the outside world
 connection_points:
   - id: "mgmt"
     interface: "ipv4"

--- a/service-descriptor/examples/default-nsd.yml
+++ b/service-descriptor/examples/default-nsd.yml
@@ -4,18 +4,18 @@
 ---
 descriptor_schema: "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/service-descriptor/nsd-schema.yml"
 
-vendor: "tango"
+vendor: "eu.5gtango"
 name: "default-nsd"
 version: "0.9"
-author: "tango"
+author: "eu.5gtango"
 description: "A default NSD with one default VNFDs"
 
 # involved network functions
 network_functions:
   - vnf_id: "vnf1"
-    vnf_vendor: "tango"
+    vnf_vendor: "eu.5gtango"
     vnf_name: "ubuntu-vnf"
-    vnf_version: "0.1"
+    vnf_version: "0.9"
 
 # NS connection points to the outside world
 connection_points:


### PR DESCRIPTION
Just minor renaming. PR to have the newest version in the repository (also used by tng-sdk-descriptorgen).