### PR TITLE
PkgFormat fix: Allow RFC3339 timestamps

### DIFF
--- a/package-specification/examples/5gtango-ns-package-example/TOSCA-Metadata/NAPD.yaml
+++ b/package-specification/examples/5gtango-ns-package-example/TOSCA-Metadata/NAPD.yaml
@@ -6,7 +6,7 @@ name: "ns-package-example"
 version: "0.1"
 package_type: "application/vnd.5gtango.package.nsp"  # MIME type of package, e.g., nsp, vnfp, tdp, trp
 maintainer: "Manuel Peuster, Paderborn University"
-release_date_time: "2018.01.01T10:00+03:00"          # IETF RFC3339
+release_date_time: "2009-01-01T10:01:02Z"          # IETF RFC3339
 description: "This is an example 5GTANGO network service package."
 logo: "Icons/upb_logo.png"                           # (optional) path to logo file (PNG or JPEG)
 

--- a/package-specification/examples/5gtango-ns-package-example/mynsd.mf
+++ b/package-specification/examples/5gtango-ns-package-example/mynsd.mf
@@ -1,7 +1,7 @@
 ns_product_name: ns-package-example
 ns_provider_id: eu.5gtango
 ns_package_version: 0.1
-ns_release_date_time: 2018.01.01T10:00+03:00
+ns_release_date_time: 2009-01-01T10:01:02Z
 
 Source: Definitions/mynsd.yaml
 Algorithm: SHA-256

--- a/package-specification/examples/5gtango-test-package-example/TOSCA-Metadata/NAPD.yaml
+++ b/package-specification/examples/5gtango-test-package-example/TOSCA-Metadata/NAPD.yaml
@@ -6,7 +6,7 @@ name: "test-package-example"
 version: "0.1"
 package_type: "application/vnd.5gtango.package.tdp"  # MIME type of package, e.g., nsp, vnfp, tdp, trp
 maintainer: "Manuel Peuster, Paderborn University"
-release_date_time: "2018.01.01T10:00+03:00"          # IETF RFC3339
+release_date_time: "2009-01-01T14:01:02-04:00"          # IETF RFC3339
 description: "This is an example 5GTANGO test package."
 logo: "Icons/upb_logo.png"                           # (optional) path to logo file (PNG or JPEG)
 

--- a/package-specification/examples/5gtango-test-package-example/mytest.mf
+++ b/package-specification/examples/5gtango-test-package-example/mytest.mf
@@ -1,7 +1,7 @@
 test_product_name: vnf-package-example
 test_provider_id: eu.5gtango
 test_package_version: 0.1
-test_release_date_time: 2018.01.01T10:00+03:00
+test_release_date_time: 2009-01-01T14:01:02-04:00
 
 Source: Definitions/mytest.yaml
 Algorithm: SHA-256

--- a/package-specification/examples/5gtango-vnf-package-example/TOSCA-Metadata/NAPD.yaml
+++ b/package-specification/examples/5gtango-vnf-package-example/TOSCA-Metadata/NAPD.yaml
@@ -6,7 +6,7 @@ name: "vnf-package-example"
 version: "0.1"
 package_type: "application/vnd.5gtango.package.vnfp"  # MIME type of package, e.g., nsp, vnfp, tdp, trp
 maintainer: "Manuel Peuster, Paderborn University"
-release_date_time: "2018.01.01T10:00+03:00"          # IETF RFC3339
+release_date_time: "2009-01-01T10:01:02Z"          # IETF RFC3339
 description: "This is an example 5GTANGO VNF package."
 logo: "Icons/upb_logo.png"                           # (optional) path to logo file (PNG or JPEG)
 

--- a/package-specification/examples/5gtango-vnf-package-example/myvnfd.mf
+++ b/package-specification/examples/5gtango-vnf-package-example/myvnfd.mf
@@ -1,7 +1,7 @@
 vnf_product_name: vnf-package-example
 vnf_provider_id: eu.5gtango
 vnf_package_version: 0.1
-vnf_release_date_time: 2018.01.01T10:00+03:00
+vnf_release_date_time: 2009-01-01T10:01:02Z
 
 Source: Definitions/myvnfd.yaml
 Algorithm: SHA-256

--- a/package-specification/examples/README.md
+++ b/package-specification/examples/README.md
@@ -5,3 +5,10 @@
 * [5GTANGO Package Specification (latest)](https://github.com/sonata-nfv/tng-schema/wiki/PkgSpec_LATEST)
 
 These folder contains some example packages. Each sub-folder represents one (unzipped) example package. To generate packages from them, just zip them and append the file ending: `*.tgo`.
+
+Create ZIPs (OS X)
+
+```
+cd package-specification/examples/5gtango-ns-package-example/
+zip -r 5gtango-ns-package-example.tgo ./
+```

--- a/package-specification/napd-schema.yml
+++ b/package-specification/napd-schema.yml
@@ -44,7 +44,7 @@ properties:
   release_date_time:
     description: "Package creation time."
     type: "string"
-    pattern: "^[A-Z0-9\\.:+]+$"
+    pattern: "^[A-Z0-9\\.:+-]+$"
   maintainer:
     description: "The person or organization that created the package."
     type: "string"


### PR DESCRIPTION
According to ETSI, timestamps should be RFC3339 compatible. The package spec. schemas didn't allow this before.

* https://pypi.python.org/pypi/pyRFC3339
* https://www.ietf.org/rfc/rfc3339.txt