### PR TITLE
include monitoring rules on behalf of the policy manager

### DIFF
--- a/policy-descriptor/README.md
+++ b/policy-descriptor/README.md
@@ -29,6 +29,19 @@ The general descriptor section also contains some optional components as outline
 - **author** (optional) describes the author of the policy descriptor.
 - **description** (optional) provides an arbitrary description of the policy.
 
+#### Monitoring Rules
+
+- **monitoring_rules** (optional) The rules used for monitoring.
+
+While the parent section is optional, once it is specified it has to have at least some of the following information:
+
+- **name** The name of the monitoring rule.
+- **description** (optional) An arbitrary description of this monitoring rule.
+- **duration** The duration the condtion has to be met before an event is fired.
+- **duration_unit** (optional) The unit of the durration, such as seconds, minutes, and hours.
+- **condition** The condition, a boolean expression, that must be met to fire the event.
+- **notification** A list of notifications that are fired when the condition is met.
+
 
 #### policyRules Section
 

--- a/policy-descriptor/examples/samplepolicydemo.yml
+++ b/policy-descriptor/examples/samplepolicydemo.yml
@@ -12,6 +12,15 @@ network_service:
   vendor: "tango"
   name: "default-nsd"
   version: "0.9"
+monitoring_rules:
+  - name: "mon:rule:vm_cpu_perc"
+    description: "Trigger events if CPU load is above 70 percent."
+    duration: 60
+    duration_unit: "s"
+    condition:  "vdu01:vm_cpu_perc > 70"
+    notification:
+      - name: "high_cpu_load"
+        type: "rabbitmq_message"
 policyRules:
   - name: "actionUponAlert"
     salience: 1
@@ -26,7 +35,7 @@ policyRules:
          type: string
          input: text
          operator: equal
-         value: 'mon_rule_vm_cpu_perc'
+         value: 'high_cpu_load'
     actions:
      - action_object: "ComponentResourceAllocationAction"
        action_type: "InfrastructureType"

--- a/policy-descriptor/policy-schema.yml
+++ b/policy-descriptor/policy-schema.yml
@@ -163,6 +163,46 @@ properties:
         description: "The version of the service descriptor."
         type: "string"
         pattern: "^[0-9\\-_.]+$"
+  monitoring_rules:
+    type: "array"
+    items:
+      type: "object"
+      properties:
+        name:
+          description: "The name of the monitoring rule."
+          type: "string"
+        description:
+          description: "An arbitrary descritpion of this monitoring rule."
+          type: "string"
+        duration:
+          description: "The duration the condtion has to be met before an event is fired."
+          type: "number"
+        duration_unit:
+          description: "The unit of the durration."
+          ref: "#/definitions/time_units"
+        condition:
+          description: "The condition, a boolean expression, that must be met to fire the event."
+          type: "string"
+        notification:
+          description: "A list of notifications that are fired when the condition is met."
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              name:
+                description: "The name of the notification"
+                type: "string"
+              type:
+                description: "The type of message that is send to the message bus."
+                type: "string"
+            required:
+              - name
+              - type
+      required:
+        - name
+        - duration
+        - condition
+        - notification
     required:
       - vendor
       - name


### PR DESCRIPTION
policy manager can also demand for some monitoring rules. These are defined per policy and the notification alerts can be consumed by the policy rules.