### PR TITLE
require either vm_flavor or resource_requirements in VDU

### DIFF
--- a/function-descriptor/examples/qos-vnfd.yml
+++ b/function-descriptor/examples/qos-vnfd.yml
@@ -48,16 +48,17 @@ virtual_deployment_units:
   - id: "vdu01"
     vm_image: "ubuntu:16.04"
     vm_image_format: "docker" 
+    # use EITHER vm_flavor (preferred) OR resource_requirements
     vm_flavor: "m1.small"
-    resource_requirements:
-      cpu:
-        vcpus: 1
-      memory:
-        size: 512
-        size_unit: "MB"
-      storage:
-        size: 10
-        size_unit: "GB"
+    # resource_requirements:
+      # cpu:
+        # vcpus: 1
+      # memory:
+        # size: 512
+        # size_unit: "MB"
+      # storage:
+        # size: 10
+        # size_unit: "GB"
     connection_points:
       - id: "mgmt"
         interface: "ipv4"

--- a/function-descriptor/examples/qos-vnfd.yml
+++ b/function-descriptor/examples/qos-vnfd.yml
@@ -48,17 +48,17 @@ virtual_deployment_units:
   - id: "vdu01"
     vm_image: "ubuntu:16.04"
     vm_image_format: "docker" 
-    # use EITHER vm_flavor (preferred) OR resource_requirements
+    # resource_requirements are always required (for MANO), optionally vm_flavor can also be specified and is then used by the SP
     vm_flavor: "m1.small"
-    # resource_requirements:
-      # cpu:
-        # vcpus: 1
-      # memory:
-        # size: 512
-        # size_unit: "MB"
-      # storage:
-        # size: 10
-        # size_unit: "GB"
+    resource_requirements:
+      cpu:
+        vcpus: 1
+      memory:
+        size: 512
+        size_unit: "MB"
+      storage:
+        size: 10
+        size_unit: "GB"
     connection_points:
       - id: "mgmt"
         interface: "ipv4"

--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -568,14 +568,9 @@ properties:
         user_data:
           description: "A script that configures the VDU during boot time."
           type: "string"
-      # use EITHER vm_flavor (preferred) OR resource_requirements (id is always required)
-      oneOf:
-        - required:
-            - id
-            - vm_flavor
-        - required:
-            - id
-            - resource_requirements
+      required:
+        - id
+        - resource_requirements
       additionalProperties: false
     minItems: 1
     uniqueItems: true

--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -568,8 +568,14 @@ properties:
         user_data:
           description: "A script that configures the VDU during boot time."
           type: "string"
-      required:
-        - id
+      # use EITHER vm_flavor (preferred) OR resource_requirements (id is always required)
+      oneOf:
+        - required:
+            - id
+            - vm_flavor
+        - required:
+            - id
+            - resource_requirements
       additionalProperties: false
     minItems: 1
     uniqueItems: true


### PR DESCRIPTION
Always require `resource_requirements` (needed by MANO). Additionally, `vm_flavor` can be specified and is then used by the SP if it's available.

Belongs to #89 