### PR TITLE
Added 'publish' field (optional) to connection points. Can be used for

### DIFF
--- a/function-descriptor/examples/cnf-vnfd.yml
+++ b/function-descriptor/examples/cnf-vnfd.yml
@@ -51,7 +51,8 @@ cloudnative_deployment_units:
     image: some-docker-hub/nginx:latest
     connection_points:
       - id: "int-http"
-        port: 80
+        port: 8080
+        publish: "80:8080"      # directly publish port of CDU (mostly for debugging, not needed for K8s)
       - id: "int-https"
         port: 443
     parameters:                 # (optional)

--- a/function-descriptor/vnfd-schema.yml
+++ b/function-descriptor/vnfd-schema.yml
@@ -124,6 +124,9 @@ definitions:
           port:
             description: "For CUDs only: Port of the container's connection point."
             type: "integer"
+          publish:
+            description: "For CUDs only: Directly publish a port of a CDU, e.g., for debugging."
+            type: "string"
           interface:
             description: "The type of connection point, such as a virtual port, a virtual NIC address, a physical port, a physcial NIC address, or the endpoint of a VPN tunnel."
             $ref: "#/definitions/interfaces"


### PR DESCRIPTION
debugging CNFs, e.g., when executed in vim-emu. see: https://github.com/sonata-nfv/son-emu/issues/295

Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>