### PR TITLE
Improving schemas

### DIFF
--- a/slice-record/examples/slice-instance-example.yml
+++ b/slice-record/examples/slice-instance-example.yml
@@ -39,7 +39,7 @@
 
 #The Network Slice Template with composed by two NetServices.
 descriptor_schema: "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/slice-descriptor/nst-schema.yml"
-id: "69e4a590-7417-4786-a629-1604636b06a6"
+uuid: "69e4a590-7417-4786-a629-1604636b06a6"
 name: "NSI_example"
 description: "This is the description of a NSI."
 vendor: "5GTango"

--- a/slice-record/examples/slice-instance-example.yml
+++ b/slice-record/examples/slice-instance-example.yml
@@ -59,6 +59,7 @@ nsr-list:
   - nsrName: "NSI_example-Service_subnet_1-1"
     nsrId: "5e28f931-7558-4a8c-9894-7a8787c4492b"
     subnet-ref: "Service_subnet_1"
+    subnet-ref-nsdId: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     sla-name: "GOLD_SLA_2"
     sla-ref: "aabbccdd-9d42-4bc9-866c-a8a3868fdf5e"
     working-status: INSTANTIATED
@@ -72,9 +73,9 @@ nsr-list:
   - nsrName: "NSI_example-Service_subnet_2-1"
     nsrId: "8efced90-1971-40d1-8a9a-d421b79ab335"
     subnet-ref: "Service_subnet_2"
+    subnet-ref-nsdId: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     sla-name: "GOLD_SLA_2"
     sla-ref: "aabbccdd-9d42-4bc9-866c-a8a3868fdf5e"
-    nsd-ref: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     working-status: INSTANTIATED
     requestId: "7ccf9584-8b1f-45f9-9193-fb3bcf4cf33e"
     vimAccountId: "0af860f6-8124-42c0-a355-2ffdd669fa51"
@@ -87,9 +88,9 @@ nsr-list:
   - nsrName: "NSI_example-Service_subnet_3-1"
     nsrId: "51957551-e562-47b3-9cc8-874053aea538"
     subnet-ref: "Service_subnet_3"
+    subnet-ref-nsdId: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     sla-name: "GOLD_SLA_2"
     sla-ref: "aabbccdd-9d42-4bc9-866c-a8a3868fdf5e"
-    nsd-ref: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     working-status: INSTANTIATED
     requestId: "1e150bc1-78fd-47b1-a0f6-30cf55dc08a9"
     vimAccountId: "0af860f6-8124-42c0-a355-2ffdd669fa51"

--- a/slice-record/examples/slice-instance-example.yml
+++ b/slice-record/examples/slice-instance-example.yml
@@ -59,6 +59,8 @@ nsr-list:
   - nsrName: "NSI_example-Service_subnet_1-1"
     nsrId: "5e28f931-7558-4a8c-9894-7a8787c4492b"
     subnet-ref: "Service_subnet_1"
+    sla-name: "GOLD_SLA_2"
+    sla-ref: "aabbccdd-9d42-4bc9-866c-a8a3868fdf5e"
     working-status: INSTANTIATED
     requestId: "1e150bc1-78fd-47b1-a0f6-30cf55dc08a9"
     vimAccountId: "0af860f6-8124-42c0-a355-2ffdd669fa51"
@@ -70,6 +72,8 @@ nsr-list:
   - nsrName: "NSI_example-Service_subnet_2-1"
     nsrId: "8efced90-1971-40d1-8a9a-d421b79ab335"
     subnet-ref: "Service_subnet_2"
+    sla-name: "GOLD_SLA_2"
+    sla-ref: "aabbccdd-9d42-4bc9-866c-a8a3868fdf5e"
     nsd-ref: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     working-status: INSTANTIATED
     requestId: "7ccf9584-8b1f-45f9-9193-fb3bcf4cf33e"
@@ -83,6 +87,8 @@ nsr-list:
   - nsrName: "NSI_example-Service_subnet_3-1"
     nsrId: "51957551-e562-47b3-9cc8-874053aea538"
     subnet-ref: "Service_subnet_3"
+    sla-name: "GOLD_SLA_2"
+    sla-ref: "aabbccdd-9d42-4bc9-866c-a8a3868fdf5e"
     nsd-ref: "6a01afdc-9d42-4bc9-866c-a8a3868fdf5e"
     working-status: INSTANTIATED
     requestId: "1e150bc1-78fd-47b1-a0f6-30cf55dc08a9"

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -119,6 +119,10 @@ properties:
         subnet-ref:
           description: "References to the ID of the slice-subnet in NST.slice_ns_subnets list."
           type: "string"
+        subnet-nsdId-ref:
+          description: "NSD uuid which this instance is based on."
+          type: "string"
+          pattern: "^[a-zA-Z0-9\\-_.]+$"
         sla-name:
           description: "Associated SLA name (from NST unless user changes it with the instantiation parameters)"
           type: "string"

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -56,7 +56,7 @@ properties:
   vendor:
     description: "Description of the NST vendor"
     type: "string"
-  nst-ref: #nstId
+  nst-ref:
     description: "The uuid of the NST used to instantiate the NSI."
     type: "string"
     pattern: "^[a-zA-Z0-9\\-_.]+$"
@@ -67,7 +67,7 @@ properties:
     description: "The version of the NetSlice Template the instance is based on."
     type: "string"
     pattern: "^[a-zA-Z0-9\\-_.]+$"
-  nsi-status: #nsiState
+  nsi-status:
     description: "State of the NSI (possible values INSTANTIATED, TERMINATED, ERROR)."
     type: string
     enum:
@@ -99,27 +99,34 @@ properties:
   sliceCallback:
     description: "Contains the URL to call back the GK when slice instantiation/termination processes are done."
     type: "string"
-  5qiValue: #qos.5qi_value
+  5qiValue:
     description: "5qi value identifies a set of 5G QoS characterisitics defined by 3GPP"
     type: "integer"
-  nsr-list: #netServInstance_Uuid
+  nsr-list:
     description: "Network Services records list generated when the NSI is requested."
     type: "array"
     items:
       description: "All the information parameters definning a netservice record."
       type: "object"
       properties:
-        nsrName: #servName
+        nsrName:
           description: "Name of the instantiation composed by the <slice_name-subnet_name-index>"
           type: "string"
-        nsrId: #servInstanceId
+        nsrId:
           description: "UUID of a network service record (instance)."
           type: "string"
           pattern: "^[a-zA-Z0-9\\-_.]+$"
         subnet-ref:
           description: "References to the ID of the slice-subnet in NST.slice_ns_subnets list."
           type: "string"
-        working-status: #workingStatus
+        sla-name:
+          description: "Associated SLA name (from NST unless user changes it with the instantiation parameters)"
+          type: "string"
+        sla-ref:
+          description: "Associated SLA Uuid (from NST unless user changes it with the instantiation parameters)"
+          type: "string"
+          pattern: "^[a-zA-Z0-9\\-_.]+$"
+        working-status:
           description: "Status of the service instantiation."
           type: "string"
           enum:

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -229,7 +229,7 @@ properties:
         - id
         - name
 required: 
-  - id
+  - uuid
   - name 
   - vendor
   - nst-ref

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -164,6 +164,8 @@ properties:
                 description: "Name of the vld connected to the nsr."
                 type: "string"
     minItems: 1
+    required:
+      - nsrName
   vldr-list:
     description: "The list of VLD uuids generated due to the instantiation of the selected NST."
     type: "array"

--- a/slice-record/nsir-schema.yml
+++ b/slice-record/nsir-schema.yml
@@ -43,7 +43,7 @@ description: "The core scheme for network slice instance (NSI)"
 
 type: "object"
 properties:
-  id:
+  uuid:
     description: "Identifies the Network Slice Instance (NSI)"
     type: "string"
     pattern: "^[a-zA-Z0-9\\-_.]+$"


### PR DESCRIPTION
- Changing id to uuid in the nsi-record.yml to work as repositorioes does (uuid instead of id).
- Added:
    · required fields for the subnets (netservices) list composing a slice
    · uuid parameter withi the subnets list items to avoid template ddbb accesses for a single nstId.